### PR TITLE
Restrict image downloads to Discord CDN URLs

### DIFF
--- a/backend/bot/downloadAndVerifyImage.py
+++ b/backend/bot/downloadAndVerifyImage.py
@@ -21,7 +21,7 @@ def download_and_verify_image(
     image_url,
 ) -> Tuple[Optional[InMemoryUploadedFile], FailureReason]:
     """
-    Downloads an image from the URL, verifies it using Pillow, and returns it.
+    Downloads an image from the Discord URL, verifies it using Pillow, and returns it.
 
     Args:
         image_url: The URL of the image to download.
@@ -43,6 +43,10 @@ def download_and_verify_image(
     }
 
     try:
+        # Validate the URL format is from Discord's CDN
+        if not image_url.startswith("https://cdn.discordapp.com/"):
+            return None, ImageError.INVALID_IMAGE
+
         # First make a HEAD request to check size before downloading
         head_response = requests.head(image_url, headers=headers, timeout=5)
         content_length = head_response.headers.get("Content-Length")


### PR DESCRIPTION
Added a check to ensure that only images hosted on Discord's CDN are downloaded and verified. This improves security by preventing downloads from arbitrary URLs.

This is not really nessesary as the URL is provided by the bots from a trusted source but it shuts up the code scanners.