### PR TITLE
Sync user guild memberships on login and add session clearing migration

### DIFF
--- a/backend/discordauth/migrations/0010_clear_sessions.py
+++ b/backend/discordauth/migrations/0010_clear_sessions.py
@@ -1,0 +1,30 @@
+# Generated migration to clear all user sessions
+from django.db import migrations
+
+
+def clear_all_sessions(apps, schema_editor):
+    """Clear all existing sessions to force users to re-login"""
+    try:
+        # Try to clear database sessions (default Django behavior)
+        from django.contrib.sessions.models import Session
+
+        Session.objects.all().delete()
+        print("Database sessions cleared successfully")
+    except Exception as e:
+        print(f"Could not clear database sessions: {e}")
+
+
+def reverse_clear_sessions(apps, schema_editor):
+    """Reverse migration - no-op since we can't restore deleted sessions"""
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("discordauth", "0009_increment_supporter_tiers"),
+    ]
+
+    operations = [
+        migrations.RunPython(clear_all_sessions, reverse_clear_sessions),
+    ]


### PR DESCRIPTION
Updated the login_success view to synchronize Member relations with the user's current Discord guilds, adding missing memberships, updating admin status, and removing stale ones. Added a migration to clear all user sessions, forcing users to re-login for improved security or data consistency.