### PR TITLE
fix bug in set default character

### DIFF
--- a/discord_bots/src/modules/setDefaultCharacter.js
+++ b/discord_bots/src/modules/setDefaultCharacter.js
@@ -46,8 +46,12 @@ async function getArgs(interaction) {
     auto_hunger: interaction.options.getBoolean("auto_hunger") ?? false,
     disable: interaction.options.getBoolean("disable") ?? false,
   };
-  const character = await getCharacter(args.autocomplete, interaction, true);
-  args.name = character.name; // getCharacter throws an error if not found, so we can assume it's valid
+  if (args.autocomplete) {
+    const character = await getCharacter(args.autocomplete, interaction, true);
+    args.name = character.name; // getCharacter throws an error if not found, so we can assume it's valid
+  } else {
+    args.name = null; // No character selected
+  }
   return args;
 }
 


### PR DESCRIPTION
Updated getArgs to set args.name to null if no character is selected, preventing errors when autocomplete is not provided.