### PR TITLE
Refactor initiative command and channel permission checks

### DIFF
--- a/discord_bots/src/modules/canSendMessage.js
+++ b/discord_bots/src/modules/canSendMessage.js
@@ -24,7 +24,7 @@ module.exports = async function canSendMessages({
       const discord_channel = await client.channels.fetch(channelId);
       if (discord_channel instanceof TextChannel) {
         channel = discord_channel;
-      }
+      } else return false;
     }
   } catch (error) {
     if (error.code === 10003)
@@ -32,7 +32,6 @@ module.exports = async function canSendMessages({
     else throw error;
   }
 
-  if (!channel.isTextBased()) return channel; // Not sending in a guild
   if (
     !channel
       .permissionsFor(channel.client.user.id)

--- a/discord_bots/src/modules/canSendMessage.js
+++ b/discord_bots/src/modules/canSendMessage.js
@@ -1,24 +1,31 @@
 "use strict";
-const { PermissionFlagsBits } = require("discord.js");
+const { PermissionFlagsBits, Client, TextChannel } = require("discord.js");
 
 /**
- * Takes in a TextChannel || a (channelId && client) and returns the channel if the
+ * Takes in a Guild TextChannel or a (channelId and client) and returns the channel if the
  * bot can post embeds in the channel.
- * @param {TextChannel} channel
- * @param {String} channelId
- * @param {Client} client
- * @returns
+ * @param {Object} options - Options for checking channel permissions.
+ * @param {TextChannel} [options.channel] - The Discord.js TextChannel instance.
+ * @param {string} [options.channelId] - The ID of the channel to fetch.
+ * @param {Client} [options.client] - The Discord.js Client instance (required if channelId is used).
+ * @returns {Promise<TextChannel|boolean>} The channel if permissions are sufficient, otherwise false.
  */
 module.exports = async function canSendMessages({
   channel = null,
   channelId = null,
   client = null,
 } = {}) {
-  if (!channel && !channelId) throw new Error("Need at least one argument");
-  if (channelId && !client) throw new Error("Need a client with an Id");
+  if (!channel && !channelId)
+    throw new Error("Need a text channel or channelId");
+  if (!channel && !client) throw new Error("Need a client with channelId");
 
   try {
-    if (!channel && channelId) channel = await client.channels.fetch(channelId);
+    if (!channel && channelId) {
+      const discord_channel = await client.channels.fetch(channelId);
+      if (discord_channel instanceof TextChannel) {
+        channel = discord_channel;
+      }
+    }
   } catch (error) {
     if (error.code === 10003)
       return false; //Unknown Channel


### PR DESCRIPTION
Updated initiative command to use ChatInputCommandInteraction and improved type annotations. Refactored canSendMessage to accept channelId and client, ensuring proper type checking for TextChannel and more robust permission validation.