### PR TITLE
Allow minimum difficulty of 0 in vtmDice command

### DIFF
--- a/discord_bots/src/commands/5th/vtmDice.js
+++ b/discord_bots/src/commands/5th/vtmDice.js
@@ -92,7 +92,7 @@ function getCommand() {
             "Number of successes needed to succeed (1-50). Defaults to 1."
           )
           .setMaxValue(50)
-          .setMinValue(1);
+          .setMinValue(0);
         return option;
       })
 


### PR DESCRIPTION
Changed the minimum value for the difficulty option from 1 to 0, allowing users to specify a difficulty of 0 when using the vtmDice command.