### PR TITLE
Fix logout URL in AppBar component

### DIFF
--- a/frontend/src/components/AppBar.js
+++ b/frontend/src/components/AppBar.js
@@ -166,7 +166,7 @@ export default function ResponsiveAppBar(props) {
           <MenuItem
             onClick={handleCloseUserMenu}
             component="a"
-            href={host + "auth/logout/"}
+            href={host + "/auth/logout/"}
           >
             <Typography textAlign="center">Logout</Typography>
           </MenuItem>


### PR DESCRIPTION
This pull request includes a minor fix to the logout link in the `ResponsiveAppBar` component, ensuring the correct URL path is used for logging out. 

* Changed the `href` for the logout menu item in `ResponsiveAppBar` to include a leading slash, correcting the logout URL.Added missing slash in the logout URL to ensure correct navigation to the logout endpoint.